### PR TITLE
Replace filemagic library with python-magic

### DIFF
--- a/chamber/forms/validators.py
+++ b/chamber/forms/validators.py
@@ -3,8 +3,8 @@ import mimetypes
 import magic  # pylint: disable=E0401
 
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext
 from django.template.defaultfilters import filesizeformat
+from django.utils.translation import ugettext
 
 
 class RestrictedFileValidator:
@@ -45,10 +45,9 @@ class AllowedContentTypesByContentFileValidator:
 
     def __call__(self, data):
         data.open()
-        with magic.Magic(flags=magic.MAGIC_MIME_TYPE) as m:
-            mime_type = m.id_buffer(data.read(2048))
-            data.seek(0)
-            if mime_type not in self.content_types:
-                raise ValidationError(ugettext('File content was evaluated as not supported file type'))
+        mime_type = magic.from_buffer(data.read(2048), mime=True)
+        data.seek(0)
+        if mime_type not in self.content_types:
+            raise ValidationError(ugettext('File content was evaluated as not supported file type'))
 
         return data

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 from chamber.version import get_version
 
@@ -32,7 +32,7 @@ setup(
         'django>=2.2, <4.0',
         'Unidecode>=1.1.1',
         'pyprind>=2.11.2',
-        'filemagic>=1.6',
+        'python-magic>=0.4.27'
     ],
     extras_require={
         'boto3storage': ['django-storages<2.0', 'boto3'],


### PR DESCRIPTION
This PR replaces `filemagic` with `python-magic`.

The `filemagic` library is no longer maintained with the last commit being 11 years ago. The compatibility with newer versions of `libmagic` is therefore not guaranteed. The library `python-magic` seems like a suitable replacement with API similar to the currently used filemagic.